### PR TITLE
Improve remote IP and location detection.

### DIFF
--- a/simple-download-monitor/includes/sdm-download-request-handler.php
+++ b/simple-download-monitor/includes/sdm-download-request-handler.php
@@ -33,9 +33,9 @@ function handle_sdm_download_via_direct_post() {
         }
         //End of password check
 
-        $ipaddress = $_SERVER["REMOTE_ADDR"];
+        $ipaddress = sdm_get_ip_address();
         $date_time = current_time('mysql');
-        $visitor_country = sdm_ip_info('Visitor', 'Country');
+        $visitor_country = $ipaddress ? sdm_ip_info($ipaddress, 'country') : '';
 
         if (is_user_logged_in()) {  // Get user name (if logged in)
             global $current_user;


### PR DESCRIPTION
Hi,

I think the problem described in this [support thread](https://wordpress.org/support/topic/download-log-on-shows-site-ip/) might be caused by simple fact that `$_SERVER["REMOTE_ADDR"]` does not always hold remote IP.

This PR fixes it by using a new method for IP detection (inspired by this [SO post](http://stackoverflow.com/questions/1634782/what-is-the-most-accurate-way-to-retrieve-a-users-correct-ip-address-in-php)). Also, it slightly simplifies `sdm_ip_info` function.

Greets,
Česlav