### PR TITLE
Add clearfix to .sdm_download_link container.

### DIFF
--- a/simple-download-monitor/css/sdm_wp_styles.css
+++ b/simple-download-monitor/css/sdm_wp_styles.css
@@ -40,6 +40,11 @@
 .sdm_download_link{
     display: block;
 }
+.sdm_download_link:after {
+    content: "";
+    display: table;
+    clear: both;
+}
 .sdm_download_button{
     display: inline-block;    
 }


### PR DESCRIPTION
...prevents download count box to overflow its (parent) link container on small screens.