### PR TITLE
Download button color

### DIFF
--- a/simple-download-monitor/includes/sdm-utility-functions.php
+++ b/simple-download-monitor/includes/sdm-utility-functions.php
@@ -1,5 +1,26 @@
 <?php
 
+
+/**
+ * Get (filtered) list of all download button colors.
+ * @return array Array of colors: color key => color name.
+ */
+function sdm_get_download_button_colors() {
+    return apply_filters('sdm_download_button_color_options', array(
+        'Green'     => __('Green', 'simple-download-monitor'),
+        'Blue'      => __('Blue', 'simple-download-monitor'),
+        'Purple'    => __('Purple', 'simple-download-monitor'),
+        'Teal'      => __('Teal', 'simple-download-monitor'),
+        'Dark Blue' => __('Dark Blue', 'simple-download-monitor'),
+        'Black'     => __('Black', 'simple-download-monitor'),
+        'Grey'      => __('Grey', 'simple-download-monitor'),
+        'Pink'      => __('Pink', 'simple-download-monitor'),
+        'Orange'    => __('Orange', 'simple-download-monitor'),
+        'White'     => __('White', 'simple-download-monitor')
+    ));
+}
+
+
 function sdm_get_download_count_for_post($id){
     // Get number of downloads by counting db columns matching postID
     global $wpdb;

--- a/simple-download-monitor/includes/templates/fancy1/sdm-fancy-1.php
+++ b/simple-download-monitor/includes/templates/fancy1/sdm-fancy-1.php
@@ -62,33 +62,21 @@ function sdm_generate_fancy1_category_display_output($get_posts, $args) {
 
 function sdm_generate_fancy1_display_output($args) {
 
-    //Get the download ID
-    $id = $args['id'];
-    if (!is_numeric($id)) {
+    $shortcode_atts = sanitize_sdm_create_download_shortcode_atts($args);
+
+    // Make shortcode attributes available in function local scope.
+    extract($shortcode_atts);
+
+    // Check the download ID
+    if ( empty($id) ) {
         return '<div class="sdm_error_msg">Error! The shortcode is missing the ID parameter. Please refer to the documentation to learn the shortcode usage.</div>';
     }
 
-    // See if user color option is selected
+    // Read plugin settings
     $main_opts = get_option('sdm_downloads_options');
-    $color_opt = $main_opts['download_button_color'];
-    $def_color = isset($color_opt) ? str_replace(' ', '', strtolower($color_opt)) : __('green', 'simple-download-monitor');
 
-    //See if new window parameter is seet
-    $window_target = '';
-    if (isset($args['new_window']) && $args['new_window'] == '1') {
-        $window_target = 'target="_blank"';
-    }
-
-    //Get the download button text
-    $button_text = isset($args['button_text']) ? $args['button_text'] : '';
-    if (empty($button_text)) {//Use the default text for the button
-        $button_text_string = __('Download Now!', 'simple-download-monitor');
-    } else {//Use the custom text
-        $button_text_string = $button_text;
-    }
-
-    // Get permalink
-    $permalink = get_permalink($id);
+    // See if new window parameter is set
+    $window_target = empty($new_window) ? '_self' : '_blank';
 
     // Get CPT thumbnail
     $item_download_thumbnail = get_post_meta($id, 'sdm_upload_thumbnail', true);    
@@ -96,7 +84,6 @@ function sdm_generate_fancy1_display_output($args) {
 
     // Get CPT title
     $item_title = get_the_title($id);
-    $isset_item_title = isset($item_title) && !empty($item_title) ? $item_title : '';
 
     // Get CPT description
     $isset_item_description = sdm_get_item_description_output($id);
@@ -104,7 +91,7 @@ function sdm_generate_fancy1_display_output($args) {
     // Get download button
     $homepage = get_bloginfo('url');
     $download_url = $homepage . '/?smd_process_download=1&download_id=' . $id;
-    $download_button_code = '<a href="' . $download_url . '" class="sdm_download ' . $def_color . '" title="' . $isset_item_title . '" ' . $window_target . '>' . $button_text_string . '</a>';
+    $download_button_code = '<a href="' . $download_url . '" class="sdm_download ' . $color . '" title="' . $item_title . '" target="' . $window_target . '">' . $button_text . '</a>';
 
     //Get item file size
     $item_file_size = get_post_meta($id, 'sdm_item_file_size', true);
@@ -132,7 +119,7 @@ function sdm_generate_fancy1_display_output($args) {
     $output .= '<div class="sdm_download_item ' . $css_class . '">';
     $output .= '<div class="sdm_download_item_top">';
     $output .= '<div class="sdm_download_thumbnail">' . $isset_download_thumbnail . '</div>';
-    $output .= '<div class="sdm_download_title">' . $isset_item_title . '</div>';
+    $output .= '<div class="sdm_download_title">' . $item_title . '</div>';
     $output .= '</div>'; //End of .sdm_download_item_top
     $output .= '<div style="clear:both;"></div>';
    

--- a/simple-download-monitor/includes/templates/fancy2/sdm-fancy-2.php
+++ b/simple-download-monitor/includes/templates/fancy2/sdm-fancy-2.php
@@ -82,28 +82,22 @@ function sdm_generate_fancy2_category_display_output($get_posts, $args) {
 
 function sdm_generate_fancy2_display_output($args) {
 
-    //Get the download ID
-    $id = $args['id'];
-    if (!is_numeric($id)) {
+    $shortcode_atts = sanitize_sdm_create_download_shortcode_atts($args);
+
+    // Make shortcode attributes available in function local scope.
+    extract($shortcode_atts);
+
+    // Check the download ID
+    if ( empty($id) ) {
         return '<div class="sdm_error_msg">Error! The shortcode is missing the ID parameter. Please refer to the documentation to learn the shortcode usage.</div>';
     }
 
-    //See if new window parameter is seet
-    $window_target = '';
-    if (isset($args['new_window']) && $args['new_window'] == '1') {
-        $window_target = 'target="_blank"';
-    }
+    // See if new window parameter is set
+    $window_target = empty($new_window) ? '_self' : '_blank';
 
-    //Get the download button text
-    $button_text = isset($args['button_text']) ? $args['button_text'] : '';
-    if (empty($button_text)) {//Use the default text for the button
-        $button_text_string = __('Download Now!', 'simple-download-monitor');
-    } else {//Use the custom text
-        $button_text_string = $button_text;
-    }
     $homepage = get_bloginfo('url');
     $download_url = $homepage . '/?smd_process_download=1&download_id=' . $id;
-    $download_button_code = '<a href="' . $download_url . '" class="sdm_fancy2_download" ' . $window_target . '>' . $button_text_string . '</a>';
+    $download_button_code = '<a href="' . $download_url . '" class="sdm_fancy2_download" target="' . $window_target . '">' . $button_text . '</a>';
 
     // Check to see if the download link cpt is password protected
     $get_cpt_object = get_post($id);
@@ -112,16 +106,12 @@ function sdm_generate_fancy2_display_output($args) {
         $download_button_code = sdm_get_password_entry_form($id);
     }
 
-    // Get item permalink
-    $permalink = get_permalink($id);
-
     // Get item thumbnail
     $item_download_thumbnail = get_post_meta($id, 'sdm_upload_thumbnail', true);
     $isset_download_thumbnail = isset($item_download_thumbnail) && !empty($item_download_thumbnail) ? '<img class="sdm_fancy2_thumb_image" src="' . $item_download_thumbnail . '" />' : '';
 
     // Get item title
     $item_title = get_the_title($id);
-    $isset_item_title = isset($item_title) && !empty($item_title) ? $item_title : '';
 
     // Get item description
     $isset_item_description = sdm_get_item_description_output($id);
@@ -144,7 +134,7 @@ function sdm_generate_fancy2_display_output($args) {
     $output .= '<div class="sdm_fancy2_download_thumbnail">' . $isset_download_thumbnail . '</div>';
     $output .= '</div>'; //End of .sdm_download_item_top
 
-    $output .= '<div class="sdm_fancy2_download_title">' . $isset_item_title . '</div>';
+    $output .= '<div class="sdm_fancy2_download_title">' . $item_title . '</div>';
     
     if (!empty($isset_item_file_size)) {//Show file size info if specified in the shortcode
         $output .= '<div class="sdm_fancy2_download_size">';

--- a/simple-download-monitor/main.php
+++ b/simple-download-monitor/main.php
@@ -542,17 +542,16 @@ class simpleDownloadManager {
 
     public function download_button_color_cb() {
         $main_opts = get_option('sdm_downloads_options');
-        $color_opt = $main_opts['download_button_color'];
-        $color_opts = array(__('Green', 'simple-download-monitor'), __('Blue', 'simple-download-monitor'), __('Purple', 'simple-download-monitor'), __('Teal', 'simple-download-monitor'), __('Dark Blue', 'simple-download-monitor'), __('Black', 'simple-download-monitor'), __('Grey', 'simple-download-monitor'), __('Pink', 'simple-download-monitor'), __('Orange', 'simple-download-monitor'), __('White', 'simple-download-monitor'));
+        // Read current color class.
+        $color_opt = isset($main_opts['download_button_color']) ? $main_opts['download_button_color'] : null;
+        $color_opts = sdm_get_download_button_colors();
+
         echo '<select name="sdm_downloads_options[download_button_color]" id="download_button_color" class="sdm_opts_ajax_dropdowns">';
-        if (isset($color_opt)) {
-            echo '<option value="' . $color_opt . '" selected="selected">' . $color_opt . ' (' . __('current', 'simple-download-monitor') . ')</option>';
-        }
-        foreach ($color_opts as $color) {
-            echo '<option value="' . $color . '">' . $color . '</option>';
+        foreach ($color_opts as $color_class => $color_name) {
+            echo '<option value="' . $color_class . '"' . selected($color_class, $color_opt, false) . '>' . $color_name . '</option>';
         }
         echo '</select> ';
-        _e('Adjusts the color of the "Download Now" button.', 'simple-download-monitor');
+        esc_html_e('Adjusts the color of the "Download Now" button.', 'simple-download-monitor');
     }
 
 }//End of simpleDownloadManager class

--- a/simple-download-monitor/main.php
+++ b/simple-download-monitor/main.php
@@ -180,8 +180,10 @@ class simpleDownloadManager {
                 download_title: '<?php _e('Download Title', 'simple-download-monitor') ?>',
                 include_fancy: '<?php _e('Include Fancy Box', 'simple-download-monitor') ?>',
                 open_new_window: '<?php _e('Open New Window', 'simple-download-monitor') ?>',
+                button_color: '<?php _e('Button Color', 'simple-download-monitor'); ?>',
                 insert_shortcode: '<?php _e('Insert SDM Shortcode', 'simple-download-monitor') ?>'
             };
+            var sdm_button_colors = <?php echo wp_json_encode(sdm_get_download_button_colors()); ?>;
         </script>
         <?php
     }

--- a/simple-download-monitor/readme.txt
+++ b/simple-download-monitor/readme.txt
@@ -112,6 +112,8 @@ Example Shortcode Usage:
 
 `[sdm_download id="271" fancy="0"]`  (embed a plain download button/link for a file)
 
+`[sdm_download id="271" fancy="0" color="blue"]`  (embed a plain download button/link for a file with a blue color)
+
 **D) Download logs**
 
 You can check the download stats from the "Downloads->Logs" interface. It shows the number of downloads for each files, IP address of the user who downloaded it, date and time of the download.

--- a/simple-download-monitor/readme.txt
+++ b/simple-download-monitor/readme.txt
@@ -2,7 +2,7 @@
 Contributors: Tips and Tricks HQ, Ruhul Amin, josh401, mbrsolution, chesio
 Donate link: https://www.tipsandtricks-hq.com
 Tags: download, downloads, count, counter, tracker, tracking, hits, logging, monitor, manager, files, media, digital, download monitor, download manager, downloadmanager, file manager, protect downloads, password, download category, file tree, ajax, download template, grid, documents, ip address
-Requires at least: 3.3.0
+Requires at least: 4.1.0
 Tested up to: 4.6
 Stable tag: 3.3.4
 License: GPLv2 or later

--- a/simple-download-monitor/tinymce/sdm_editor_plugin.js
+++ b/simple-download-monitor/tinymce/sdm_editor_plugin.js
@@ -91,31 +91,36 @@ jQuery(function(){
 			}
 		}
 	);
+
+        var button_color_options = '';
+        for ( var color in sdm_button_colors ) {
+            button_color_options += '<option value="' + color + '">' + sdm_button_colors[color] + '</option>';
+        }
 				
 	// Instantiate a form in the wp thickbox window (hidden at start)		
     var form = jQuery('<div id="highlight-form"><div id="sdm_tinymce_postids" style="display:none;"></div>\
 						<div id="sdm_select_title" style="margin-top:20px;">'+tinymce_langs.select_download_item+'</div>\
 						<table id="highlight-table" class="form-table" style="text-align: left">\
-							\
-							\
 						<tr>\
-						<th><label class="title" for="highlight-bg">'+tinymce_langs.download_title+'</label></th>\
-							<td><select name="sdm_select" id="sdm_select">\
-							</select><br />\
+						    <th><label class="title" for="sdm_select">'+tinymce_langs.download_title+'</label></th>\
+						    <td><select name="sdm_select" id="sdm_select"></select></td>\
 						</tr>\
 						<tr>\
-						<th><label class="sdm_fancy" for "sdm_fancy_option">'+tinymce_langs.include_fancy+'</th>\
-							<td><input type="checkbox" name="sdm_fancy_cb" id="sdm_fancy_cb" />\
+						    <th><label class="sdm_fancy" for="sdm_fancy_cb">'+tinymce_langs.include_fancy+'</th>\
+						    <td><input type="checkbox" name="sdm_fancy_cb" id="sdm_fancy_cb" /></td>\
 						</tr>\
 						<tr>\
-						<th><label class="sdm_new_window" for "sdm_open_new_window">'+tinymce_langs.open_new_window+'</th>\
-							<td><input type="checkbox" name="sdm_open_new_window_cb" id="sdm_open_new_window_cb" />\
+						    <th><label class="color" for="sdm_button_color">'+tinymce_langs.button_color+'</label></th>\
+						    <td><select name="sdm_button_color" id="sdm_button_color">' + button_color_options + '</select></td>\
+						</tr>\
+						<tr>\
+						    <th><label class="sdm_new_window" for="sdm_open_new_window_cb">'+tinymce_langs.open_new_window+'</th>\
+						    <td><input type="checkbox" name="sdm_open_new_window_cb" id="sdm_open_new_window_cb" /></td>\
 						</tr>\
                                                 </table>\
 						<p class="submit">\
 							<input type="button" id="sdm-tinymce-submit" class="button-primary" value="'+tinymce_langs.insert_shortcode+'" name="submit" style=""/>\
 						</p>\
-						<p></p>\
 					   </div>');
 
     var table = form.find('table');
@@ -124,25 +129,30 @@ jQuery(function(){
     // handles the click event of the submit button
     form.find('#sdm-tinymce-submit').click(function(){
 
-        fancy_cb = jQuery('#sdm_fancy_cb').is(':checked');
-        new_window_cb = jQuery('#sdm_open_new_window_cb').is(':checked');
-        post_id = jQuery('#sdm_select').find(":selected").val();  // Get selected CPT item title value (item id)
+        var fancy_cb = jQuery('#sdm_fancy_cb').is(':checked');
+        var new_window_cb = jQuery('#sdm_open_new_window_cb').is(':checked');
+        var post_id = jQuery('#sdm_select').find(":selected").val();  // Get selected CPT item title value (item id)
+        var color = jQuery('#sdm_button_color').find(":selected").val();  // Get selected CPT item title value (item id)
 
         //Build the shortcode with parameters according to the options
-        shortcode = '[sdm_download id="'+post_id+'"';
+        var shortcode = '[sdm_download id="'+post_id+'"';
 
         //Add the fancy parameter to the shortcode (if needed
-        if (jQuery('#sdm_fancy_cb').is(':checked')) {
+        if ( fancy_cb ) {
             shortcode = shortcode + ' fancy="1"';
         } else {
             shortcode = shortcode + ' fancy="0"';
         }
           
         //Add the new_window parameter to the shortcode (if needed)
-        if (jQuery('#sdm_open_new_window_cb').is(':checked')) {
+        if ( new_window_cb ) {
             shortcode = shortcode + ' new_window="1"';
         }
         
+        if ( color ) {
+            shortcode += ' color="' + color + '"';
+        }
+
         shortcode = shortcode + ']';//End the shortcode
 
         // inserts the shortcode into the active editor


### PR DESCRIPTION
This pull request implements:

1. Filterable list of download button colors (any new color styles have to be implemented in theme's style.css or similar). There's a potentially breaking change: instead of storing of localized value of `__('Green', 'sdm-download-monitor')`, only the value of `'Green'` is stored in plugin settings now. I wonder, how the button color setting worked for languages that have available translations for colors, because there are no corresponding CSS class names for localized color names... Ie. I believe it didn't, but maybe no one noticed :)
1. New `color` parameter for `sdm_download` button that allows to override default color setting. The related shortcode rendering functions were quite messy, I couldn't resist to clean them up a bit. Still, they contain quite a lot of duplicate code.
1. Support for setting of `color` parameter via shortcode helper (pop-up window). The last feature uses [wp_json_encode](https://developer.wordpress.org/reference/functions/wp_json_encode/) function that is only available since WP 4.1. An alternative would be to use native [json_encode](http://php.net/manual/en/function.json-encode.php) function, but _wp_json_encode_ is a more robust implementation.

Every item in the list above corresponds to a single commit - for easier review. Changes have been tested on WP 4.6.1.

Greetings,
Česlav