### PR TITLE
Use wp_safe_remote_get to retrieve geoplugin data

### DIFF
--- a/simple-download-monitor/includes/sdm-utility-functions.php
+++ b/simple-download-monitor/includes/sdm-utility-functions.php
@@ -108,7 +108,8 @@ function sdm_ip_info($ip, $purpose = "location") {
         "SA" => "South America"
     );
 
-    $ipdat = @json_decode(file_get_contents("http://www.geoplugin.net/json.gp?ip=" . $ip));
+    $res = wp_safe_remote_get("http://www.geoplugin.net/json.gp?ip=" . $ip);
+    $ipdat = @json_decode($res['response']['message']);
 
     if (@strlen(trim($ipdat->geoplugin_countryCode)) === 2) {
         switch ($purpose) {


### PR DESCRIPTION
Using file_get_contents($url) won't work if your Wordpress server requires an HTTP Proxy to reach the Internet, e.g. if it (the Wordpress server) has a private IP address.

wp_safe_remote_get uses Wordpress's built-in HTTP client, which is aware of constants like WP_PROXY_HOST and WP_PROXY_PORT.