### PR TITLE
Fix fancy templates: some shortcode attributes have been ignored.

### DIFF
--- a/simple-download-monitor/includes/templates/fancy1/sdm-fancy-1.php
+++ b/simple-download-monitor/includes/templates/fancy1/sdm-fancy-1.php
@@ -3,23 +3,11 @@
 function sdm_generate_fancy1_latest_downloads_display_output($get_posts, $args) {
 
     $output = "";
-    isset($args['button_text']) ? $button_text = $args['button_text'] : $button_text = '';
-    isset($args['new_window']) ? $new_window = $args['new_window'] : $new_window = '';
-    isset($args['show_size']) ? $show_size = $args['show_size'] : $show_size = '';
-    isset($args['show_version']) ? $show_version = $args['show_version'] : $show_version = '';
     
     foreach ($get_posts as $item) {
-        $id = $item->ID;  //Get the post ID
-        //Create a args array
-        $args = array(
-            'id' => $id,
-            'fancy' => '1',
-            'button_text' => $button_text,
-            'new_window' => $new_window,
-            'show_size' => $show_size,
-            'show_version' => $show_version,
+        $output .= sdm_generate_fancy1_display_output(
+            array_merge($args, array('id' => $item->ID))
         );
-        $output .= sdm_generate_fancy1_display_output($args);
     }
     $output .= '<div class="sdm_clear_float"></div>';
     return $output;
@@ -32,23 +20,10 @@ function sdm_generate_fancy1_category_display_output($get_posts, $args) {
     //TODO - when the CSS file is moved to the fancy1 folder, change it here
     //$output .= '<link type="text/css" rel="stylesheet" href="' . WP_SIMPLE_DL_MONITOR_URL . '/includes/templates/fancy1/sdm-fancy-1-styles.css?ver=' . WP_SIMPLE_DL_MONITOR_VERSION . '" />';
     
-    isset($args['button_text']) ? $button_text = $args['button_text'] : $button_text = '';
-    isset($args['new_window']) ? $new_window = $args['new_window'] : $new_window = '';
-    isset($args['show_size']) ? $show_size = $args['show_size'] : $show_size = '';
-    isset($args['show_version']) ? $show_version = $args['show_version'] : $show_version = '';
-    
     foreach ($get_posts as $item) {
-        $id = $item->ID;  //Get the post ID
-        //Create a args array
-        $args = array(
-            'id' => $id,
-            'fancy' => '1',
-            'button_text' => $button_text,
-            'new_window' => $new_window,
-            'show_size' => $show_size,
-            'show_version' => $show_version,            
+        $output .= sdm_generate_fancy1_display_output(
+            array_merge($args, array('id' => $item->ID))
         );
-        $output .= sdm_generate_fancy1_display_output($args);
     }
     $output .= '<div class="sdm_clear_float"></div>';
     return $output;
@@ -60,9 +35,19 @@ function sdm_generate_fancy1_category_display_output($get_posts, $args) {
  * id, fancy, button_text, new_window
  */
 
-function sdm_generate_fancy1_display_output($args) {
+function sdm_generate_fancy1_display_output($atts) {
 
-    $shortcode_atts = sanitize_sdm_create_download_shortcode_atts($args);
+    $shortcode_atts = sanitize_sdm_create_download_shortcode_atts(
+        shortcode_atts(array(
+            'id' => '',
+            'button_text' => __('Download Now!', 'simple-download-monitor'),
+            'new_window' => '',
+            'color' => '',
+            'css_class' => '',
+            'show_size' => '',
+            'show_version' => '',
+        ), $atts)
+    );
 
     // Make shortcode attributes available in function local scope.
     extract($shortcode_atts);
@@ -95,11 +80,11 @@ function sdm_generate_fancy1_display_output($args) {
 
     //Get item file size
     $item_file_size = get_post_meta($id, 'sdm_item_file_size', true);
-    $isset_item_file_size = (isset($args['show_size']) && isset($item_file_size)) ? $item_file_size : '';//check if show_size is enabled and if there is a size value
+    $isset_item_file_size = ($show_size && isset($item_file_size)) ? $item_file_size : '';//check if show_size is enabled and if there is a size value
 
     //Get item version
     $item_version = get_post_meta($id, 'sdm_item_version', true);
-    $isset_item_version = (isset($args['show_version']) && isset($item_version)) ? $item_version : '';//check if show_version is enabled and if there is a version value
+    $isset_item_version = ($show_version && isset($item_version)) ? $item_version : '';//check if show_version is enabled and if there is a version value
 
     // Check to see if the download link cpt is password protected
     $get_cpt_object = get_post($id);
@@ -111,8 +96,6 @@ function sdm_generate_fancy1_display_output($args) {
     $db_count = sdm_get_download_count_for_post($id);
     $string = ($db_count == '1') ? __('Download', 'simple-download-monitor') : __('Downloads', 'simple-download-monitor');
     $download_count_string = '<span class="sdm_item_count_number">' . $db_count . '</span><span class="sdm_item_count_string"> ' . $string . '</span>';
-
-    $css_class = isset($args['css_class']) ? $args['css_class'] : '';
 
     $output = '';
 

--- a/simple-download-monitor/includes/templates/fancy2/sdm-fancy-2.php
+++ b/simple-download-monitor/includes/templates/fancy2/sdm-fancy-2.php
@@ -10,23 +10,9 @@ function sdm_generate_fancy2_latest_downloads_display_output($get_posts, $args) 
     $count = 1;
     //$output .= '<ul class="sdm_fancy2_category_items">';
     foreach ($get_posts as $item) {
-        $id = $item->ID;  //Get the post ID
-        $button_text = isset($args['button_text'])? $args['button_text'] : '';
-        $new_window = isset($args['new_window'])? $args['new_window'] : '';
-        $show_size = isset($args['show_size'])? $args['show_size'] : '';
-        $show_version = isset($args['show_version'])? $args['show_version'] : '';
-    
-        //Create a args array
-        $args = array(
-            'id' => $id,
-            'fancy' => '2',
-            'button_text' => $button_text,
-            'new_window' => $new_window,
-            'css_class' => 'sdm_fancy2_grid',
-            'show_size' => $show_size,
-            'show_version' => $show_version,            
+        $output .= sdm_generate_fancy2_display_output(
+            array_merge($args, array('id' => $item->ID))
         );
-        $output .= sdm_generate_fancy2_display_output($args);
 
         if ($count % 3 == 0) {//Clear after every 3 items in the grid
             $output .= '<div class="sdm_clear_float"></div>';
@@ -46,23 +32,9 @@ function sdm_generate_fancy2_category_display_output($get_posts, $args) {
     $count = 1;
     //$output .= '<ul class="sdm_fancy2_category_items">';
     foreach ($get_posts as $item) {
-        $id = $item->ID;  //Get the post ID
-        $button_text = isset($args['button_text'])? $args['button_text'] : '';
-        $new_window = isset($args['new_window'])? $args['new_window'] : '';
-        $show_size = isset($args['show_size'])? $args['show_size'] : '';
-        $show_version = isset($args['show_version'])? $args['show_version'] : '';
-        
-        //Create a args array
-        $args = array(
-            'id' => $id,
-            'fancy' => '2',
-            'button_text' => $button_text,
-            'new_window' => $new_window,
-            'css_class' => 'sdm_fancy2_grid',
-            'show_size' => $show_size,
-            'show_version' => $show_version,            
+        $output .= sdm_generate_fancy2_display_output(
+            array_merge($args, array('id' => $item->ID))
         );
-        $output .= sdm_generate_fancy2_display_output($args);
 
         if ($count % 3 == 0) {//Clear after every 3 items in the grid
             $output .= '<div class="sdm_clear_float"></div>';
@@ -80,9 +52,19 @@ function sdm_generate_fancy2_category_display_output($get_posts, $args) {
  * id, fancy, button_text, new_window
  */
 
-function sdm_generate_fancy2_display_output($args) {
+function sdm_generate_fancy2_display_output($atts) {
 
-    $shortcode_atts = sanitize_sdm_create_download_shortcode_atts($args);
+    $shortcode_atts = sanitize_sdm_create_download_shortcode_atts(
+        shortcode_atts(array(
+            'id' => '',
+            'button_text' => __('Download Now!', 'simple-download-monitor'),
+            'new_window' => '',
+            'color' => '',
+            'css_class' => 'sdm_fancy2_grid',
+            'show_size' => '',
+            'show_version' => '',
+        ), $atts)
+    );
 
     // Make shortcode attributes available in function local scope.
     extract($shortcode_atts);
@@ -118,14 +100,13 @@ function sdm_generate_fancy2_display_output($args) {
 
     //Get item file size
     $item_file_size = get_post_meta($id, 'sdm_item_file_size', true);
-    $isset_item_file_size = (isset($args['show_size']) && isset($item_file_size)) ? $item_file_size : '';//check if show_size is enabled and if there is a size value
+    $isset_item_file_size = ($show_size && isset($item_file_size)) ? $item_file_size : '';//check if show_size is enabled and if there is a size value
 
     //Get item version
     $item_version = get_post_meta($id, 'sdm_item_version', true);
-    $isset_item_version = (isset($args['show_version']) && isset($item_version)) ? $item_version : '';//check if show_version is enabled and if there is a version value
+    $isset_item_version = ($show_version && isset($item_version)) ? $item_version : '';//check if show_version is enabled and if there is a version value
 
     
-    $css_class = isset($args['css_class']) ? $args['css_class'] : '';
     $output = '';
     $output .= '<div class="sdm_fancy2_item ' . $css_class . '">';
     $output .= '<div class="sdm_fancy2_wrapper">';


### PR DESCRIPTION
In #8, I broke button text display for `sdm_show_dl_from_category` shortcode as reported [here](https://wordpress.org/support/topic/sdm-no-fancey-2-download-text/).

Also, I've missed that `sdm_generate_fancy1_display_output` and `sdm_generate_fancy2_display_output` functions accept more attributes (like css_class, show_size and show_version).

This PR attempts to fix it and also cleans up `sdm_handle_category_shortcode` function a bit.