### PR TITLE
Add ability not capture IP address of user on Download files

### DIFF
--- a/simple-download-monitor/includes/sdm-download-request-handler.php
+++ b/simple-download-monitor/includes/sdm-download-request-handler.php
@@ -39,12 +39,16 @@ function handle_sdm_download_via_direct_post() {
 	}
 	//End of password check
 
-	$ipaddress = sdm_get_ip_address();
+        $main_option = get_option('sdm_downloads_options');
+        
+        $ipaddress = null;
+        if (!isset($main_option['admin_do_not_capture_ip'])) {
+            $ipaddress = sdm_get_ip_address();
+        }
+        
 	$date_time = current_time('mysql');
 	$visitor_country = $ipaddress ? sdm_ip_info($ipaddress, 'country') : '';
-
-	$main_option = get_option('sdm_downloads_options');
-
+	
 	$visitor_name = sdm_get_logged_in_user();
 
 	// Check if we only allow the download for logged-in users

--- a/simple-download-monitor/main.php
+++ b/simple-download-monitor/main.php
@@ -568,6 +568,7 @@ class simpleDownloadManager {
 
 	add_settings_field('admin_tinymce_button', __('Remove Tinymce Button', 'simple-download-monitor'), array($this, 'admin_tinymce_button_cb'), 'admin_options_section', 'admin_options');
 	add_settings_field('admin_log_unique', __('Log Unique IP', 'simple-download-monitor'), array($this, 'admin_log_unique'), 'admin_options_section', 'admin_options');
+	add_settings_field('admin_do_not_capture_ip', __('Do Not Capture IP Address', 'simple-download-monitor'), array($this, 'admin_do_not_capture_ip'), 'admin_options_section', 'admin_options');
 	add_settings_field('admin_dont_log_bots', __('Do Not Count Downloads from Bots', 'simple-download-monitor'), array($this, 'admin_dont_log_bots'), 'admin_options_section', 'admin_options');
 	add_settings_field('admin_no_logs', __('Disable Download Logs', 'simple-download-monitor'), array($this, 'admin_no_logs_cb'), 'admin_options_section', 'admin_options');
 
@@ -640,6 +641,12 @@ class simpleDownloadManager {
 	$main_opts = get_option('sdm_downloads_options');
 	echo '<input name="sdm_downloads_options[admin_log_unique]" id="admin_log_unique" type="checkbox" class="sdm_opts_ajax_checkboxes" ' . checked(1, isset($main_opts['admin_log_unique']), false) . ' /> ';
 	echo '<label for="admin_log_unique">' . __('Only logs downloads from unique IP addresses.', 'simple-download-monitor') . '</label>';
+    }
+    
+    public function admin_do_not_capture_ip() {
+	$main_opts = get_option('sdm_downloads_options');
+	echo '<input name="sdm_downloads_options[admin_do_not_capture_ip]" id="admin_do_not_capture_ip" type="checkbox" class="sdm_opts_ajax_checkboxes" ' . checked(1, isset($main_opts['admin_do_not_capture_ip']), false) . ' /> ';
+	echo '<label for="admin_do_not_capture_ip">' . __('Do Not Capture IP Address', 'simple-download-monitor') . '</label>';
     }
 
     public function admin_dont_log_bots() {


### PR DESCRIPTION
The Task
------------
At the moment, when a vistor downloads an item, the plugin will log/capture the following details:
Title, File, Visitor IP, Date, Country, Username
A NEW settings option should be added in the settings menu of the plugin so the IP address collection can be turned off by the admin (if he wants to).

1. So add a new checkbox called "Do Not Capture IP Address" in the settings menu of the plugin.
2. When this checkbox is enabled, insert empty string "" in the IP address column.
