### PR TITLE
Use the correct WordPress capability to update meta fields

### DIFF
--- a/simple-download-monitor/includes/admin-side/sdm-admin-edit-download.php
+++ b/simple-download-monitor/includes/admin-side/sdm-admin-edit-download.php
@@ -24,15 +24,12 @@ class SDM_Admin_Edit_Download {
 	}
 
 	public function remove_thumbnail_image_ajax_handler() {
-
-		// terminates the script if the nonce verification fails.
-		check_ajax_referer( 'sdm_remove_thumbnail_nonce_action', 'sdm_remove_thumbnail_nonce' );
-
-		if ( ! current_user_can( 'manage_options' ) ) {
-			// Permission denied
-			wp_die( esc_html( __( 'Permission denied!', 'simple-download-monitor' ) ) );
-			exit;
-		}
+        $sdm_post_capability = apply_filters( 'sdm_post_type_capability', 'manage_options' );
+        if( ! current_user_can( $sdm_post_capability ) ) {
+            // Permission denied
+            wp_die( esc_html( __( 'Permission denied!', 'simple-download-monitor' ) ) );
+            exit;
+        }
 
 		// Go ahead with the thumbnail removal
 		$post_id    = filter_input( INPUT_POST, 'post_id_del', FILTER_SANITIZE_NUMBER_INT );
@@ -315,7 +312,11 @@ class SDM_Admin_Edit_Download {
 			return;
 		}
 
-		check_admin_referer( 'sdm_admin_edit_download_' . $post_id, 'sdm_admin_edit_download' );
+		$sdm_post_capability = apply_filters( 'sdm_post_type_capability', 'manage_options' );
+        if( ! current_user_can( $sdm_post_capability ) ) {
+            // Permission denied
+            return;
+        }
 
 		// *** Description  ***
 		if ( isset( $_POST['sdm_description'] ) ) {


### PR DESCRIPTION
We've noticed that non-admin users who can access downloads will get an error when they attempt to publish a download item. In these cases, the download post itself would be created and get published, but the meta values aren't being saved.

This pull aims to resolve that by getting the correct WordPress capability to update these fields through the `sdm_post_type_capability` filter.